### PR TITLE
feat: update mutation api test

### DIFF
--- a/env-tester.sh
+++ b/env-tester.sh
@@ -1,3 +1,0 @@
-# Set env to test backend.ai components through client-py.
-export BACKENDAI_TEST_CLIENT_VENV=/Users/sh/.pyenv/versions/venv-dev-client
-export BACKENDAI_TEST_CLIENT_ENV=/Users/sh/dev/client-py/env-local-admin-api.sh

--- a/env-tester.sh
+++ b/env-tester.sh
@@ -1,0 +1,3 @@
+# Set env to test backend.ai components through client-py.
+export BACKENDAI_TEST_CLIENT_VENV=/Users/sh/.pyenv/versions/venv-dev-client
+export BACKENDAI_TEST_CLIENT_ENV=/Users/sh/dev/client-py/env-local-admin-api.sh

--- a/src/ai/backend/test/cli_integration/admin/test_domain.py
+++ b/src/ai/backend/test/cli_integration/admin/test_domain.py
@@ -19,7 +19,8 @@ def test_add_domain(run: ClientRunnerFunc):
     ]
     with closing(run(add_arguments)) as p:
         p.expect(EOF)
-        assert 'Domain name test is created.' in p.before.decode(), 'Domain creation not successful'
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, 'Domain creation has failed'
 
     # Check if domain is added
     with closing(run(['--output=json', 'admin', 'domain', 'list'])) as p:
@@ -55,7 +56,8 @@ def test_update_domain(run: ClientRunnerFunc):
     ]
     with closing(run(add_arguments)) as p:
         p.expect(EOF)
-        assert 'Domain test is updated.' in p.before.decode(), 'Domain update not successful'
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, 'Domain update has failed'
 
     # Check if domain is updated
     with closing(run(['--output=json', 'admin', 'domain', 'list'])) as p:
@@ -83,7 +85,8 @@ def test_delete_domain(run: ClientRunnerFunc):
     with closing(run(['admin', 'domain', 'purge', 'test123'])) as p:
         p.sendline('y')
         p.expect(EOF)
-        assert 'Domain is deleted:' in p.before.decode(), 'Domain deletion failed'
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, 'Domain deletion has failed'
 
 
 def test_list_domain(run: ClientRunnerFunc):

--- a/src/ai/backend/test/cli_integration/admin/test_group.py
+++ b/src/ai/backend/test/cli_integration/admin/test_group.py
@@ -1,23 +1,138 @@
 import json
 from contextlib import closing
+from typing import Iterator
 
 from ...utils.cli import EOF, ClientRunnerFunc
 
 
-def test_add_group(run: ClientRunnerFunc):
-    pass
+def test_add_group(run: ClientRunnerFunc, temp_domain: Iterator[str]):
+    with closing(run([
+        '--output=json',
+        'admin', 'group', 'add',
+        temp_domain,
+        'test_user_group',
+    ])) as p:
+        p.expect(EOF)
+        json_result = json.loads(p.before.decode())
+        assert json_result.get('ok'), 'Group creation has failed'
+        gid = json_result['group']['id']
+
+    # Delete the created group
+    with closing(run([
+        'admin', 'group', 'purge', gid,
+    ])) as p:
+        p.expect_exact("Are you sure? [Y/n]")
+        p.sendline('y')
+        p.expect(EOF)
 
 
-def test_update_group(run: ClientRunnerFunc):
-    pass
+def test_add_users_to_group(run: ClientRunnerFunc, temp_domain: Iterator[str]):
+    # Create a testing group
+    with closing(run([
+        '--output=json',
+        'admin', 'group', 'add',
+        temp_domain,
+        'test_user_group',
+    ])) as p:
+        p.expect(EOF)
+        json_result = json.loads(p.before.decode())
+        gid = json_result['group']['id']
+
+    # Create a testing user
+    add_arguments = ['admin', 'user', 'add', 'default', 'test_user@lablup.com', '1q2w3e4r']
+    with closing(run(add_arguments)) as p:
+        p.expect(EOF)
+
+    # Get user's UUID
+    add_arguments = ['--output=json', 'admin', 'user', 'list']
+    with closing(run(add_arguments)) as p:
+        p.expect(EOF)
+        json_result = json.loads(p.before.decode())
+        user = [user if user['email'] == 'test_user@lablup.com' else None for user in json_result['items']][0]
+
+    with closing(run([
+        '--output=json',
+        'admin', 'group', 'add-users',
+        gid,
+        user['uuid'],
+    ])) as p:
+        p.expect(EOF)
+        json_result = json.loads(p.before.decode())
+        assert json_result.get('ok'), 'Group update has failed'
+
+    # Delete testing user
+    add_arguments = ['admin', 'user', 'purge', user['email']]
+    with closing(run(add_arguments)) as p:
+        p.sendline('y')
+        p.expect(EOF)
+
+    # Delete the created group
+    with closing(run([
+        'admin', 'group', 'purge', gid,
+    ])) as p:
+        p.expect_exact("Are you sure? [Y/n]")
+        p.sendline('y')
+        p.expect(EOF)
 
 
-def test_delete_group(run: ClientRunnerFunc):
-    pass
+def test_update_group(run: ClientRunnerFunc, temp_domain: Iterator[str]):
+    # Create a testing group
+    with closing(run([
+        '--output=json',
+        'admin', 'group', 'add',
+        temp_domain,
+        'test_user_group',
+    ])) as p:
+        p.expect(EOF)
+        json_result = json.loads(p.before.decode())
+        gid = json_result['group']['id']
+
+    with closing(run([
+        '--output=json',
+        'admin', 'group', 'update',
+        '-n', 'new_name',
+        '-d', 'Description here',
+        gid,
+    ])) as p:
+        p.expect(EOF)
+        json_result = json.loads(p.before.decode())
+        assert json_result.get('ok'), 'Group update has failed'
+
+    # Delete the created group
+    with closing(run([
+        'admin', 'group', 'purge', gid,
+    ])) as p:
+        p.expect_exact("Are you sure? [Y/n]")
+        p.sendline('y')
+        p.expect(EOF)
+
+
+def test_delete_group(run: ClientRunnerFunc, temp_domain: Iterator[str]):
+    # Create a testing group
+    with closing(run([
+        '--output=json',
+        'admin', 'group', 'add',
+        temp_domain,
+        'test_user_group',
+    ])) as p:
+        p.expect(EOF)
+        json_result = json.loads(p.before.decode())
+        gid = json_result['group']['id']
+
+    # Delete a testing group
+    with closing(run([
+        '--output=json', 'admin', 'group', 'purge', gid,
+    ])) as p:
+        p.expect_exact("Are you sure? [Y/n]")
+        p.sendline('y')
+        p.expect(EOF)
+        std_output = p.before.decode()
+        json_output = std_output[std_output.index('{'):std_output.index('}') + 1]
+        json_result = json.loads(json_output)
+        assert json_result.get('ok'), 'Group deletion has failed'
 
 
 def test_list_group(run: ClientRunnerFunc):
-    print("[ List group ]")
     with closing(run(['--output=json', 'admin', 'group', 'list'])) as p:
         p.expect(EOF)
         decoded = p.before.decode()

--- a/src/ai/backend/test/cli_integration/admin/test_keypair.py
+++ b/src/ai/backend/test/cli_integration/admin/test_keypair.py
@@ -15,22 +15,26 @@ def test_add_keypair(run: ClientRunnerFunc):
                      '-r', 'admin', 'default', 'adminkeypair@lablup.com', '1q2w3e4r']
     with closing(run(add_arguments)) as p:
         p.expect(EOF)
-        assert 'User adminkeypair@lablup.com is created' in p.before.decode(), 'Account add error'
+        json_result = json.loads(p.before.decode())
+        assert json_result.get('ok'), 'User creation has failed'
 
     add_arguments = ['--output=json', 'admin', 'user', 'add', '-u', 'userkeypair', '-n', 'Richard Doe',
                      'default', 'userkeypair@lablup.com', '1q2w3e4r']
     with closing(run(add_arguments)) as p:
         p.expect(EOF)
-        assert 'User userkeypair@lablup.com is created' in p.before.decode(), 'Account add error'
+        json_result = json.loads(p.before.decode())
+        assert json_result.get('ok'), 'User creation has failed'
 
     # Create keypair
     with closing(run(['admin', 'keypair', 'add', '-a', '-i', '-r', '25000', 'adminkeypair@lablup.com', 'default'])) as p:
         p.expect(EOF)
-        assert 'Access Key:' in p.before.decode() and 'Secret Key:' in p.before.decode(), 'Keypair add error'
+        listed_result = p.before.decode().split()
+        assert 'access_key' in listed_result and 'secret_key' in listed_result, 'Admin-keypair creation has failed'
 
     with closing(run(['admin', 'keypair', 'add', 'userkeypair@lablup.com', 'default'])) as p:
         p.expect(EOF)
-        assert 'Access Key:' in p.before.decode() and 'Secret Key:' in p.before.decode(), 'Keypair add error'
+        listed_result = p.before.decode().split()
+        assert 'access_key' in listed_result and 'secret_key' in listed_result, 'User-keypair creation has failed'
 
     # Check if keypair is added
     with closing(run(['--output=json', 'admin', 'keypair', 'list'])) as p:
@@ -84,7 +88,8 @@ def test_update_keypair(run: ClientRunnerFunc):
         admin_keypair['access_key'],
     ])) as p:
         p.expect(EOF)
-        assert 'Key pair is updated:' in p.before.decode(), 'Admin keypair update error'
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, 'Admin keypair update has failed'
 
     with closing(run([
         'admin', 'keypair', 'update',
@@ -94,7 +99,8 @@ def test_update_keypair(run: ClientRunnerFunc):
         user_keypair['access_key'],
     ])) as p:
         p.expect(EOF)
-        assert 'Key pair is updated:' in p.before.decode(), 'User keypair update error'
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, 'User keypair update has failed'
 
     # Check if keypair is updated
     with closing(run(['--output=json', 'admin', 'keypair', 'list'])) as p:
@@ -142,22 +148,26 @@ def test_delete_keypair(run: ClientRunnerFunc):
     # Delete keypair
     with closing(run(['admin', 'keypair', 'delete', admin_keypair['access_key']])) as p:
         p.expect(EOF)
-        print(p.before.decode())
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, 'Admin-keypair deletion has failed'
 
     with closing(run(['admin', 'keypair', 'delete', user_keypair['access_key']])) as p:
         p.expect(EOF)
-        print(p.before.decode())
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, 'User-keypair deletion has failed'
 
     # Delete test user
     with closing(run(['admin', 'user', 'purge', 'adminkeypair@lablup.com'])) as p:
         p.sendline('y')
         p.expect(EOF)
-        assert 'User is deleted:' in p.before.decode(), 'Account deletion failed: adminkeypair'
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, 'Admin user deletion has failed'
 
     with closing(run(['admin', 'user', 'purge', 'userkeypair@lablup.com'])) as p:
         p.sendline('y')
         p.expect(EOF)
-        assert 'User is deleted:' in p.before.decode(), 'Account deletion failed: userkeypair'
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, 'User deletion has failed'
 
 
 def test_list_keypair(run: ClientRunnerFunc):

--- a/src/ai/backend/test/cli_integration/admin/test_keypair_resource_policy.py
+++ b/src/ai/backend/test/cli_integration/admin/test_keypair_resource_policy.py
@@ -22,8 +22,9 @@ def test_add_keypair_resource_policy(run: ClientRunnerFunc):
     ]
     with closing(run(add_arguments)) as p:
         p.expect(EOF)
-        assert 'Keypair resource policy test_krp is created.' in p.before.decode(), \
-            'Keypair resource policy creation not successful'
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, \
+            'Keypair resource policy creation has failed'
 
     # Check if keypair resource policy is created
     with closing(run(['--output=json', 'admin', 'keypair-resource-policy', 'list'])) as p:
@@ -65,7 +66,9 @@ def test_update_keypair_resource_policy(run: ClientRunnerFunc):
     ]
     with closing(run(add_arguments)) as p:
         p.expect(EOF)
-        assert 'Update succeeded.' in p.before.decode(), 'Keypair resource policy update not successful'
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, \
+            'Keypair resource policy update has failed'
 
     # Check if keypair resource policy is updated
     with closing(run(['--output=json', 'admin', 'keypair-resource-policy', 'list'])) as p:
@@ -96,7 +99,9 @@ def test_delete_keypair_resource_policy(run: ClientRunnerFunc):
     with closing(run(['admin', 'keypair-resource-policy', 'delete', 'test_krp'])) as p:
         p.sendline('y')
         p.expect(EOF)
-        assert 'Resource policy test_krp is deleted.' in p.before.decode(), 'Keypair resource policy deletion failed'
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, \
+            'Keypair resource policy deletion has failed'
 
 
 def test_list_keypair_resource_policy(run: ClientRunnerFunc):

--- a/src/ai/backend/test/cli_integration/admin/test_scaling_group.py
+++ b/src/ai/backend/test/cli_integration/admin/test_scaling_group.py
@@ -16,8 +16,8 @@ def test_add_scaling_group(run: ClientRunnerFunc):
         'test_group1',
     ])) as p:
         p.expect(EOF)
-        assert 'Scaling group name test_group1 is created.' in p.before.decode(), \
-            'Test scaling group not created successfully'
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, 'Scaling group creation has failed'
 
     # Check if scaling group is created
     with closing(run(['--output=json', 'admin', 'scaling-group', 'list'])) as p:
@@ -57,8 +57,8 @@ def test_update_scaling_group(run: ClientRunnerFunc):
         'test_group1',
     ])) as p:
         p.expect(EOF)
-        assert 'Scaling group test_group1 is updated.' in p.before.decode(), \
-            'Test scaling group not updated successfully'
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, 'Scaling group update has failed'
 
     # Check if scaling group is updated
     with closing(run(['--output=json', 'admin', 'scaling-group', 'info', 'test_group1'])) as p:
@@ -82,7 +82,8 @@ def test_update_scaling_group(run: ClientRunnerFunc):
 def test_delete_scaling_group(run: ClientRunnerFunc):
     with closing(run(['admin', 'scaling-group', 'delete', 'test_group1'])) as p:
         p.expect(EOF)
-        assert 'Scaling group is deleted: test_group1.' in p.before.decode(), 'Test scaling group deletion unsuccessful'
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, 'Scaling group deletion has failed'
 
 
 def test_list_scaling_group(run: ClientRunnerFunc):

--- a/src/ai/backend/test/cli_integration/admin/test_user.py
+++ b/src/ai/backend/test/cli_integration/admin/test_user.py
@@ -33,7 +33,8 @@ def test_add_user(run: ClientRunnerFunc):
         ]
         with closing(run(add_arguments)) as p:
             p.expect(EOF)
-            assert 'User testaccount1@lablup.com is created' in p.before.decode(), 'Account add error'
+            json_result = json.loads(p.before.decode())
+            assert json_result.get('ok'), 'User creation has failed'
 
     if not bool(test_user2):
         # Add user
@@ -49,7 +50,8 @@ def test_add_user(run: ClientRunnerFunc):
         ]
         with closing(run(add_arguments)) as p:
             p.expect(EOF)
-            assert 'User testaccount2@lablup.com is created' in p.before.decode(), 'Account add error'
+            json_result = json.loads(p.before.decode())
+            assert json_result.get('ok'), 'User creation has failed'
 
     if not bool(test_user3):
         # Add user
@@ -65,7 +67,8 @@ def test_add_user(run: ClientRunnerFunc):
         ]
         with closing(run(add_arguments)) as p:
             p.expect(EOF)
-            assert 'User testaccount3@lablup.com is created' in p.before.decode(), 'Account add error'
+            json_result = json.loads(p.before.decode())
+            assert json_result.get('ok'), 'User creation has failed'
 
     # Check if user is added
     with closing(run(['--output=json', 'admin', 'user', 'list'])) as p:
@@ -174,17 +177,20 @@ def test_delete_user(run: ClientRunnerFunc):
     with closing(run(['admin', 'user', 'purge', 'testaccount1@lablup.com'])) as p:
         p.sendline('y')
         p.expect(EOF)
-        assert 'User is deleted:' in p.before.decode(), 'Account deletion failed: Account#1'
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, 'User deletion has failed'
 
     with closing(run(['admin', 'user', 'purge', 'testaccount2@lablup.com'])) as p:
         p.sendline('y')
         p.expect(EOF)
-        assert 'User is deleted:' in p.before.decode(), 'Account deletion failed: Account#2'
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, 'User deletion has failed'
 
     with closing(run(['admin', 'user', 'purge', 'testaccount3@lablup.com'])) as p:
         p.sendline('y')
         p.expect(EOF)
-        assert 'User is deleted:' in p.before.decode(), 'Account deletion failed: Account#3'
+        listed_result = p.before.decode().split()
+        assert listed_result.index('ok') == listed_result.index('True') - 1, 'User deletion has failed'
 
 
 def test_list_user(run: ClientRunnerFunc):

--- a/src/ai/backend/test/cli_integration/conftest.py
+++ b/src/ai/backend/test/cli_integration/conftest.py
@@ -61,12 +61,13 @@ def domain_name() -> str:
 
 @pytest.fixture
 def temp_domain(domain_name: str, run: ClientRunnerFunc) -> Iterator[str]:
-    run(['admin', 'domains', 'add', domain_name])
+    with closing(run(['admin', 'domain', 'add', domain_name])) as p:
+        p.expect(EOF)
+
     print("==== temp_domain created ====")
     try:
         yield domain_name
     finally:
-        with closing(run(['admin', 'domains', 'purge', domain_name])) as p:
-            p.expect_exact("Are you sure?")
+        with closing(run(['admin', 'domain', 'purge', domain_name])) as p:
             p.sendline("Y")
             p.expect(EOF)


### PR DESCRIPTION
client-py에서 https://github.com/lablup/backend.ai-client-py/pull/198 로 인해 `--output=json` 옵션을 설정한 mutation 요청의 출력이 바뀌었습니다.
이에 따라 업데이트하는 커밋입니다.

그리고 admin group 커맨드의 테스트 코드도 추가했습니다.

blocked by https://github.com/lablup/backend.ai-client-py/pull/198 