### PR TITLE
fix: Change format mismatches in user test assertions

### DIFF
--- a/src/ai/backend/test/cli_integration/admin/test_domain.py
+++ b/src/ai/backend/test/cli_integration/admin/test_domain.py
@@ -9,6 +9,7 @@ def test_add_domain(run: ClientRunnerFunc):
 
     # Add domain
     add_arguments = [
+        '--output=json',
         'admin', 'domain', 'add',
         '-d', 'Test domain',
         '-i',
@@ -19,7 +20,8 @@ def test_add_domain(run: ClientRunnerFunc):
     ]
     with closing(run(add_arguments)) as p:
         p.expect(EOF)
-        assert 'Domain name test is created.' in p.before.decode(), 'Domain creation not successful'
+        response = json.loads(p.before.decode())
+        assert response.get('ok') is True, 'Domain creation not successful'
 
     # Check if domain is added
     with closing(run(['--output=json', 'admin', 'domain', 'list'])) as p:
@@ -44,6 +46,7 @@ def test_update_domain(run: ClientRunnerFunc):
 
     # Update domain
     add_arguments = [
+        '--output=json',
         'admin', 'domain', 'update',
         '--new-name', 'test123',
         '--description', 'Test domain updated',
@@ -55,7 +58,8 @@ def test_update_domain(run: ClientRunnerFunc):
     ]
     with closing(run(add_arguments)) as p:
         p.expect(EOF)
-        assert 'Domain test is updated.' in p.before.decode(), 'Domain update not successful'
+        response = json.loads(p.before.decode())
+        assert response.get('ok') is True, 'Domain update not successful'
 
     # Check if domain is updated
     with closing(run(['--output=json', 'admin', 'domain', 'list'])) as p:
@@ -80,10 +84,12 @@ def test_delete_domain(run: ClientRunnerFunc):
     print("[ Delete domain ]")
 
     # Delete domain
-    with closing(run(['admin', 'domain', 'purge', 'test123'])) as p:
+    with closing(run(['--output=json', 'admin', 'domain', 'purge', 'test123'])) as p:
         p.sendline('y')
         p.expect(EOF)
-        assert 'Domain is deleted:' in p.before.decode(), 'Domain deletion failed'
+        before = p.before.decode()
+        response = json.loads(before[before.index('{'):])
+        assert response.get('ok') is True, 'Domain deletion failed'
 
 
 def test_list_domain(run: ClientRunnerFunc):

--- a/src/ai/backend/test/cli_integration/admin/test_keypair_resource_policy.py
+++ b/src/ai/backend/test/cli_integration/admin/test_keypair_resource_policy.py
@@ -9,6 +9,7 @@ def test_add_keypair_resource_policy(run: ClientRunnerFunc):
 
     # Add keypair resource policy
     add_arguments = [
+        '--output=json',
         'admin', 'keypair-resource-policy', 'add',
         '--default-for-unspecified', 'LIMITED',
         '--total-resource-slots', '{}',
@@ -22,8 +23,8 @@ def test_add_keypair_resource_policy(run: ClientRunnerFunc):
     ]
     with closing(run(add_arguments)) as p:
         p.expect(EOF)
-        assert 'Keypair resource policy test_krp is created.' in p.before.decode(), \
-            'Keypair resource policy creation not successful'
+        response = json.loads(p.before.decode())
+        assert response.get('ok') is True, 'Keypair resource policy creation not successful'
 
     # Check if keypair resource policy is created
     with closing(run(['--output=json', 'admin', 'keypair-resource-policy', 'list'])) as p:
@@ -52,6 +53,7 @@ def test_update_keypair_resource_policy(run: ClientRunnerFunc):
 
     # Update keypair resource policy
     add_arguments = [
+        '--output=json',
         'admin', 'keypair-resource-policy', 'update',
         '--default-for-unspecified', 'UNLIMITED',
         '--total-resource-slots', '{}',
@@ -65,7 +67,8 @@ def test_update_keypair_resource_policy(run: ClientRunnerFunc):
     ]
     with closing(run(add_arguments)) as p:
         p.expect(EOF)
-        assert 'Update succeeded.' in p.before.decode(), 'Keypair resource policy update not successful'
+        response = json.loads(p.before.decode())
+        assert response.get('ok') is True, 'Keypair resource policy update not successful'
 
     # Check if keypair resource policy is updated
     with closing(run(['--output=json', 'admin', 'keypair-resource-policy', 'list'])) as p:
@@ -93,10 +96,12 @@ def test_delete_keypair_resource_policy(run: ClientRunnerFunc):
     print("[ Delete keypair resource policy ]")
 
     # Delete keypair resource policy
-    with closing(run(['admin', 'keypair-resource-policy', 'delete', 'test_krp'])) as p:
+    with closing(run(['--output=json', 'admin', 'keypair-resource-policy', 'delete', 'test_krp'])) as p:
         p.sendline('y')
         p.expect(EOF)
-        assert 'Resource policy test_krp is deleted.' in p.before.decode(), 'Keypair resource policy deletion failed'
+        before = p.before.decode()
+        response = json.loads(before[before.index('{'):])
+        assert response.get('ok') is True, 'Keypair resource policy deletion failed'
 
 
 def test_list_keypair_resource_policy(run: ClientRunnerFunc):

--- a/src/ai/backend/test/cli_integration/admin/test_user.py
+++ b/src/ai/backend/test/cli_integration/admin/test_user.py
@@ -33,7 +33,8 @@ def test_add_user(run: ClientRunnerFunc):
         ]
         with closing(run(add_arguments)) as p:
             p.expect(EOF)
-            assert 'User testaccount1@lablup.com is created' in p.before.decode(), 'Account add error'
+            response = json.loads(p.before.decode())
+            assert response.get('ok') is True, 'Account creation failed: Account#1'
 
     if not bool(test_user2):
         # Add user
@@ -49,7 +50,8 @@ def test_add_user(run: ClientRunnerFunc):
         ]
         with closing(run(add_arguments)) as p:
             p.expect(EOF)
-            assert 'User testaccount2@lablup.com is created' in p.before.decode(), 'Account add error'
+            response = json.loads(p.before.decode())
+            assert response.get('ok') is True, 'Account creation failed: Account#2'
 
     if not bool(test_user3):
         # Add user
@@ -65,7 +67,8 @@ def test_add_user(run: ClientRunnerFunc):
         ]
         with closing(run(add_arguments)) as p:
             p.expect(EOF)
-            assert 'User testaccount3@lablup.com is created' in p.before.decode(), 'Account add error'
+            response = json.loads(p.before.decode())
+            assert response.get('ok') is True, 'Account creation failed: Account#3'
 
     # Check if user is added
     with closing(run(['--output=json', 'admin', 'user', 'list'])) as p:
@@ -171,20 +174,27 @@ def test_delete_user(run: ClientRunnerFunc):
     Testcase for user deletion.
     """
     print("[ Delete user ]")
-    with closing(run(['admin', 'user', 'purge', 'testaccount1@lablup.com'])) as p:
-        p.sendline('y')
-        p.expect(EOF)
-        assert 'User is deleted:' in p.before.decode(), 'Account deletion failed: Account#1'
 
-    with closing(run(['admin', 'user', 'purge', 'testaccount2@lablup.com'])) as p:
+    with closing(run(['--output=json', 'admin', 'user', 'purge', 'testaccount1@lablup.com'])) as p:
         p.sendline('y')
         p.expect(EOF)
-        assert 'User is deleted:' in p.before.decode(), 'Account deletion failed: Account#2'
+        before = p.before.decode()
+        response = json.loads(before[before.index('{'):])
+        assert response.get('ok') is True, 'Account deletion failed: Account#1'
 
-    with closing(run(['admin', 'user', 'purge', 'testaccount3@lablup.com'])) as p:
+    with closing(run(['--output=json', 'admin', 'user', 'purge', 'testaccount2@lablup.com'])) as p:
         p.sendline('y')
         p.expect(EOF)
-        assert 'User is deleted:' in p.before.decode(), 'Account deletion failed: Account#3'
+        before = p.before.decode()
+        response = json.loads(before[before.index('{'):])
+        assert response.get('ok') is True, 'Account deletion failed: Account#2'
+
+    with closing(run(['--output=json', 'admin', 'user', 'purge', 'testaccount3@lablup.com'])) as p:
+        p.sendline('y')
+        p.expect(EOF)
+        before = p.before.decode()
+        response = json.loads(before[before.index('{'):])
+        assert response.get('ok') is True, 'Account deletion failed: Account#3'
 
 
 def test_list_user(run: ClientRunnerFunc):


### PR DESCRIPTION
Some test cases fail because of their outdated assertions; the responses from the latest client do not contain the expected message anymore. I found such mismatches from methods below:
- `ai.backend.test.cli_integration.admin.test_user#test_add_user`
- `ai.backend.test.cli_integration.admin.test_user#test_delete_user`

and they are fixed in this PR.

For details, please check the referenced issue below.

Refs:
- lablup/backend.ai#426