### PR TITLE
fix: Replace dummy data to randomized fixture

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ setup_requires =
     setuptools>=46.1.0
 install_requires =
     click~=8.0.1
+    faker~=13.12.0
     pytest~=6.2.1
     pytest-dependency
     backend.ai-cli~=0.3

--- a/src/ai/backend/test/cli_integration/admin/test_domain.py
+++ b/src/ai/backend/test/cli_integration/admin/test_domain.py
@@ -9,6 +9,7 @@ def test_add_domain(run: ClientRunnerFunc):
 
     # Add domain
     add_arguments = [
+        '--output=json',
         'admin', 'domain', 'add',
         '-d', 'Test domain',
         '-i',
@@ -19,7 +20,8 @@ def test_add_domain(run: ClientRunnerFunc):
     ]
     with closing(run(add_arguments)) as p:
         p.expect(EOF)
-        assert 'Domain name test is created.' in p.before.decode(), 'Domain creation not successful'
+        response = json.loads(p.before.decode())
+        assert response.get('ok') is True, 'Domain creation not successful'
 
     # Check if domain is added
     with closing(run(['--output=json', 'admin', 'domain', 'list'])) as p:
@@ -44,6 +46,7 @@ def test_update_domain(run: ClientRunnerFunc):
 
     # Update domain
     add_arguments = [
+        '--output=json',
         'admin', 'domain', 'update',
         '--new-name', 'test123',
         '--description', 'Test domain updated',
@@ -55,7 +58,8 @@ def test_update_domain(run: ClientRunnerFunc):
     ]
     with closing(run(add_arguments)) as p:
         p.expect(EOF)
-        assert 'Domain test is updated.' in p.before.decode(), 'Domain update not successful'
+        response = json.loads(p.before.decode())
+        assert response.get('ok') is True, 'Domain update not successful'
 
     # Check if domain is updated
     with closing(run(['--output=json', 'admin', 'domain', 'list'])) as p:
@@ -80,10 +84,12 @@ def test_delete_domain(run: ClientRunnerFunc):
     print("[ Delete domain ]")
 
     # Delete domain
-    with closing(run(['admin', 'domain', 'purge', 'test123'])) as p:
+    with closing(run(['--output=json', 'admin', 'domain', 'purge', 'test123'])) as p:
         p.sendline('y')
         p.expect(EOF)
-        assert 'Domain is deleted:' in p.before.decode(), 'Domain deletion failed'
+        before = p.before.decode()
+        response = json.loads(before[before.index('{'):])
+        assert response.get('ok') is True, 'Domain deletion failed'
 
 
 def test_list_domain(run: ClientRunnerFunc):

--- a/src/ai/backend/test/cli_integration/admin/test_keypair.py
+++ b/src/ai/backend/test/cli_integration/admin/test_keypair.py
@@ -1,10 +1,12 @@
 import json
 from contextlib import closing
+from typing import Tuple
 
+from ..conftest import KeypairOption
 from ...utils.cli import EOF, ClientRunnerFunc
 
 
-def test_add_keypair(run: ClientRunnerFunc):
+def test_add_keypair(run: ClientRunnerFunc, users: Tuple[dict], keypair_options: Tuple[KeypairOption]):
     """
     Test add keypair.
     This test should be execued first in test_keypair.py.
@@ -12,30 +14,38 @@ def test_add_keypair(run: ClientRunnerFunc):
     print("[ Add keypair ]")
 
     # Add test user
-    add_arguments = ['--output=json', 'admin', 'user', 'add', '-u', 'adminkeypair', '-n', 'John Doe',
-                     '-r', 'admin', 'default', 'adminkeypair@lablup.com', '1q2w3e4r']
-    with closing(run(add_arguments)) as p:
-        p.expect(EOF)
-        response = json.loads(p.before.decode())
-        assert response.get('ok') is True, 'Account#1 add error'
-
-    add_arguments = ['--output=json', 'admin', 'user', 'add', '-u', 'userkeypair', '-n', 'Richard Doe',
-                     'default', 'userkeypair@lablup.com', '1q2w3e4r']
-    with closing(run(add_arguments)) as p:
-        p.expect(EOF)
-        response = json.loads(p.before.decode())
-        assert response.get('ok') is True, 'Account#2 add error'
+    for i, user in enumerate(users):
+        add_arguments = [
+            '--output=json', 'admin', 'user', 'add',
+            '-u', user['username'],
+            '-n', user['full_name'],
+            '-r', user['role'],
+            'default',
+            user['email'],
+            user['password'],
+        ]
+        with closing(run(add_arguments)) as p:
+            p.expect(EOF)
+            response = json.loads(p.before.decode())
+            assert response.get('ok') is True, f'Account#{i+1} add error'
 
     # Create keypair
-    with closing(run(['--output=json', 'admin', 'keypair', 'add', '-a', '-i', '-r', '25000', 'adminkeypair@lablup.com', 'default'])) as p:
-        p.expect(EOF)
-        response = json.loads(p.before.decode())
-        assert response.get('ok') is True, 'Keypair#1 add error'
-
-    with closing(run(['--output=json', 'admin', 'keypair', 'add', 'userkeypair@lablup.com', 'default'])) as p:
-        p.expect(EOF)
-        response = json.loads(p.before.decode())
-        assert response.get('ok') is True, 'Keypair#2 add error'
+    for i, (user, keypair_option) in enumerate(zip(users, keypair_options)):
+        keypair_add_arguments = [
+            '--output=json', 'admin', 'keypair', 'add',
+            user['email'],
+            'default',
+        ]
+        if keypair_option.is_active is False:
+            keypair_add_arguments.append('--inactive')
+        if keypair_option.is_admin:
+            keypair_add_arguments.append('--admin')
+        if (rate_limit := keypair_option.rate_limit) is not None:
+            keypair_add_arguments.extend(['--rate-limit', rate_limit])
+        with closing(run(keypair_add_arguments)) as p:
+            p.expect(EOF)
+            response = json.loads(p.before.decode())
+            assert response.get('ok') is True, f'Keypair#{i+1} add error'
 
     # Check if keypair is added
     with closing(run(['--output=json', 'admin', 'keypair', 'list'])) as p:
@@ -45,28 +55,23 @@ def test_add_keypair(run: ClientRunnerFunc):
         keypair_list = loaded.get('items')
         assert isinstance(keypair_list, list), 'List not printed properly!'
 
-    admin_keypair = get_keypair_from_list(keypair_list, 'adminkeypair@lablup.com')
-    user_keypair = get_keypair_from_list(keypair_list, 'userkeypair@lablup.com')
-
-    assert 'access_key' in admin_keypair, 'Admin keypair doesn\'t exist'
-    assert admin_keypair.get('is_active') is False, 'Admin keypair is_active mismatch'
-    assert admin_keypair.get('is_admin') is True, 'Admin keypair is_admin mismatch'
-    assert admin_keypair.get('rate_limit') == 25000, 'Admin keypair rate_limit mismatch'
-    assert admin_keypair.get('resource_policy') == 'default', 'Admin keypair resource_policy mismatch'
-
-    assert 'access_key' in user_keypair, 'Admin keypair doesn\'t exist'
-    assert user_keypair.get('is_active') is True, 'User keypair is_active mismatch'
-    assert user_keypair.get('is_admin') is False, 'User keypair is_admin mismatch'
-    assert user_keypair.get('rate_limit') == 5000, 'User keypair rate_limit mismatch'
-    assert user_keypair.get('resource_policy') == 'default', 'User keypair resource_policy mismatch'
+    for i, (user, keypair_option) in enumerate(zip(users, keypair_options)):
+        keypair = get_keypair_from_list(keypair_list, user['email'])
+        assert 'access_key' in keypair, f'Keypair#{i+1} doesn\'t exist'
+        assert keypair.get('is_active') is keypair_option.is_active, f'Keypair#{i+1} is_active mismatch'
+        assert keypair.get('is_admin') is keypair_option.is_admin, f'Keypair#{i+1} is_admin mismatch'
+        if (rate_limit := keypair_option.rate_limit) is not None:
+            assert keypair.get('rate_limit') == rate_limit, f'Keypair#{i+1} rate_limit mismatch'
+        assert keypair.get('resource_policy') == keypair_option.resource_policy, f'Keypair#{i+1} resource_policy mismatch'
 
 
-def test_update_keypair(run: ClientRunnerFunc):
+def test_update_keypair(run: ClientRunnerFunc, users: Tuple[dict], new_keypair_options: Tuple[KeypairOption]):
     """
     Test update keypair.
     This test must be executed after test_add_keypair.
     """
     print("[ Update keypair ]")
+
     # Get access key
     with closing(run(['--output=json', 'admin', 'keypair', 'list'])) as p:
         p.expect(EOF)
@@ -75,35 +80,21 @@ def test_update_keypair(run: ClientRunnerFunc):
         keypair_list = loaded.get('items')
         assert isinstance(keypair_list, list), 'List not printed properly!'
 
-    admin_keypair = get_keypair_from_list(keypair_list, 'adminkeypair@lablup.com')
-    user_keypair = get_keypair_from_list(keypair_list, 'userkeypair@lablup.com')
-    assert 'access_key' in admin_keypair, 'Admin keypair info doesn\'t exist'
-    assert 'access_key' in user_keypair, 'User keypair info doesn\'t exist'
+    for i, (user, new_keypair_option) in enumerate(zip(users, new_keypair_options)):
+        keypair = get_keypair_from_list(keypair_list, user['email'])
+        assert 'access_key' in keypair, f'Keypair#{i+1} info doesn\'t exist'
 
-    # Update keypair
-    with closing(run([
-        '--output=json',
-        'admin', 'keypair', 'update',
-        '--is-active', 'TRUE',
-        '--is-admin', 'FALSE',
-        '-r', '15000',
-        admin_keypair['access_key'],
-    ])) as p:
-        p.expect(EOF)
-        response = json.loads(p.before.decode())
-        assert response.get('ok') is True, 'Admin keypair update error'
-
-    with closing(run([
-        '--output=json',
-        'admin', 'keypair', 'update',
-        '--is-active', 'FALSE',
-        '--is-admin', 'TRUE',
-        '-r', '15000',
-        user_keypair['access_key'],
-    ])) as p:
-        p.expect(EOF)
-        response = json.loads(p.before.decode())
-        assert response.get('ok') is True, 'User keypair update error'
+        keypair_update_arguments = [
+            '--output=json', 'admin', 'keypair', 'update',
+            '--is-active', 'TRUE' if bool(new_keypair_option.is_active) else 'FALSE',
+            '--is-admin', str(bool(new_keypair_option.is_admin)).upper(),
+            '--rate-limit', new_keypair_option.rate_limit,
+            keypair['access_key'],
+        ]
+        with closing(run(keypair_update_arguments)) as p:
+            p.expect(EOF)
+            response = json.loads(p.before.decode())
+            assert response.get('ok') is True, f'Keypair#{i+1} update error'
 
     # Check if keypair is updated
     with closing(run(['--output=json', 'admin', 'keypair', 'list'])) as p:
@@ -113,28 +104,23 @@ def test_update_keypair(run: ClientRunnerFunc):
         updated_keypair_list = loaded.get('items')
         assert isinstance(updated_keypair_list, list), 'List not printed properly!'
 
-    updated_admin_keypair = get_keypair_from_list(updated_keypair_list, 'adminkeypair@lablup.com')
-    updated_user_keypair = get_keypair_from_list(updated_keypair_list, 'userkeypair@lablup.com')
-
-    assert 'access_key' in updated_admin_keypair, 'Admin keypair doesn\'t exist'
-    assert updated_admin_keypair.get('is_active') is True, 'Admin keypair is_active mismatch'
-    assert updated_admin_keypair.get('is_admin') is False, 'Admin keypair is_admin mismatch'
-    assert updated_admin_keypair.get('rate_limit') == 15000, 'Admin keypair rate_limit mismatch'
-    assert updated_admin_keypair.get('resource_policy') == 'default', 'Admin keypair resource_policy mismatch'
-
-    assert 'access_key' in updated_user_keypair, 'Admin keypair doesn\'t exist'
-    assert updated_user_keypair.get('is_active') is False, 'User keypair is_active mismatch'
-    assert updated_user_keypair.get('is_admin') is True, 'User keypair is_admin mismatch'
-    assert updated_user_keypair.get('rate_limit') == 15000, 'User keypair rate_limit mismatch'
-    assert updated_user_keypair.get('resource_policy') == 'default', 'User keypair resource_policy mismatch'
+    for i, (user, new_keypair_opt) in enumerate(zip(users, new_keypair_options)):
+        updated_keypair = get_keypair_from_list(updated_keypair_list, user['email'])
+        assert 'access_key' in updated_keypair, f'Keypair#{i+1} doesn\'t exist'
+        assert updated_keypair.get('is_active') is new_keypair_opt.is_active, f'Keypair#{i+1} is_active mismatch'
+        assert updated_keypair.get('is_admin') is new_keypair_opt.is_admin, f'Keypair#{i+1} is_admin mismatch'
+        assert updated_keypair.get('rate_limit') == new_keypair_opt.rate_limit, f'Keypair#{i+1} rate_limit mismatch'
+        assert updated_keypair.get('resource_policy') == new_keypair_opt.resource_policy, \
+                                                                            f'Keypair#{i+1} resource_policy mismatch'
 
 
-def test_delete_keypair(run: ClientRunnerFunc):
+def test_delete_keypair(run: ClientRunnerFunc, users: Tuple[dict]):
     """
     Test delete keypair.
     This test must be executed after test_add_keypair.
     """
     print("[ Delete keypair ]")
+
     # Get access key
     with closing(run(['--output=json', 'admin', 'keypair', 'list'])) as p:
         p.expect(EOF)
@@ -143,32 +129,21 @@ def test_delete_keypair(run: ClientRunnerFunc):
         keypair_list = loaded.get('items')
         assert isinstance(keypair_list, list), 'List not printed properly!'
 
-    admin_keypair = get_keypair_from_list(keypair_list, 'adminkeypair@lablup.com')
-    user_keypair = get_keypair_from_list(keypair_list, 'userkeypair@lablup.com')
-    assert 'access_key' in admin_keypair, 'Admin keypair info doesn\'t exist'
-    assert 'access_key' in user_keypair, 'User keypair info doesn\'t exist'
+    for i, user in enumerate(users):
+        keypair = get_keypair_from_list(keypair_list, user['email'])
+        assert 'access_key' in keypair, f'Keypair#{i+1} info doesn\'t exist'
 
-    # Delete keypair
-    with closing(run(['admin', 'keypair', 'delete', admin_keypair['access_key']])) as p:
-        p.expect(EOF)
+        # Delete keypair
+        with closing(run(['admin', 'keypair', 'delete', keypair['access_key']])) as p:
+            p.expect(EOF)
 
-    with closing(run(['admin', 'keypair', 'delete', user_keypair['access_key']])) as p:
-        p.expect(EOF)
-
-    # Delete test user
-    with closing(run(['--output=json', 'admin', 'user', 'purge', 'adminkeypair@lablup.com'])) as p:
-        p.sendline('y')
-        p.expect(EOF)
-        before = p.before.decode()
-        response = json.loads(before[before.index('{'):])
-        assert response.get('ok') is True, 'Account deletion failed: adminkeypair'
-
-    with closing(run(['--output=json', 'admin', 'user', 'purge', 'userkeypair@lablup.com'])) as p:
-        p.sendline('y')
-        p.expect(EOF)
-        before = p.before.decode()
-        response = json.loads(before[before.index('{'):])
-        assert response.get('ok') is True, 'Account deletion failed: userkeypair'
+        # Delete test user
+        with closing(run(['--output=json', 'admin', 'user', 'purge', user['email']])) as p:
+            p.sendline('y')
+            p.expect(EOF)
+            before = p.before.decode()
+            response = json.loads(before[before.index('{'):])
+            assert response.get('ok') is True, f'Account deletion failed: {user["username"]}'
 
 
 def test_list_keypair(run: ClientRunnerFunc):

--- a/src/ai/backend/test/cli_integration/admin/test_keypair.py
+++ b/src/ai/backend/test/cli_integration/admin/test_keypair.py
@@ -1,12 +1,28 @@
 import json
+from collections import namedtuple
 from contextlib import closing
 from typing import Tuple
 
-from ..conftest import KeypairOption
 from ...utils.cli import EOF, ClientRunnerFunc
 
+KeypairOption = namedtuple('KeypairOption',
+                           ('is_active', 'is_admin', 'rate_limit', 'resource_policy'))
 
-def test_add_keypair(run: ClientRunnerFunc, users: Tuple[dict], keypair_options: Tuple[KeypairOption]):
+
+keypair_options = (
+    KeypairOption(is_active=False, is_admin=True, rate_limit=25000, resource_policy='default'),
+    KeypairOption(is_active=True, is_admin=False, rate_limit=None, resource_policy='default'),
+    KeypairOption(is_active=True, is_admin=True, rate_limit=30000, resource_policy='default'),
+)
+
+new_keypair_options = (
+    KeypairOption(is_active=True, is_admin=False, rate_limit=15000, resource_policy='default'),
+    KeypairOption(is_active=False, is_admin=True, rate_limit=15000, resource_policy='default'),
+    KeypairOption(is_active=False, is_admin=False, rate_limit=10000, resource_policy='default'),
+)
+
+
+def test_add_keypair(run: ClientRunnerFunc, users: Tuple[dict]):
     """
     Test add keypair.
     This test should be execued first in test_keypair.py.
@@ -65,7 +81,7 @@ def test_add_keypair(run: ClientRunnerFunc, users: Tuple[dict], keypair_options:
         assert keypair.get('resource_policy') == keypair_option.resource_policy, f'Keypair#{i+1} resource_policy mismatch'
 
 
-def test_update_keypair(run: ClientRunnerFunc, users: Tuple[dict], new_keypair_options: Tuple[KeypairOption]):
+def test_update_keypair(run: ClientRunnerFunc, users: Tuple[dict]):
     """
     Test update keypair.
     This test must be executed after test_add_keypair.

--- a/src/ai/backend/test/cli_integration/admin/test_keypair_resource_policy.py
+++ b/src/ai/backend/test/cli_integration/admin/test_keypair_resource_policy.py
@@ -9,6 +9,7 @@ def test_add_keypair_resource_policy(run: ClientRunnerFunc):
 
     # Add keypair resource policy
     add_arguments = [
+        '--output=json',
         'admin', 'keypair-resource-policy', 'add',
         '--default-for-unspecified', 'LIMITED',
         '--total-resource-slots', '{}',
@@ -22,8 +23,8 @@ def test_add_keypair_resource_policy(run: ClientRunnerFunc):
     ]
     with closing(run(add_arguments)) as p:
         p.expect(EOF)
-        assert 'Keypair resource policy test_krp is created.' in p.before.decode(), \
-            'Keypair resource policy creation not successful'
+        response = json.loads(p.before.decode())
+        assert response.get('ok') is True, 'Keypair resource policy creation not successful'
 
     # Check if keypair resource policy is created
     with closing(run(['--output=json', 'admin', 'keypair-resource-policy', 'list'])) as p:
@@ -52,6 +53,7 @@ def test_update_keypair_resource_policy(run: ClientRunnerFunc):
 
     # Update keypair resource policy
     add_arguments = [
+        '--output=json',
         'admin', 'keypair-resource-policy', 'update',
         '--default-for-unspecified', 'UNLIMITED',
         '--total-resource-slots', '{}',
@@ -65,7 +67,8 @@ def test_update_keypair_resource_policy(run: ClientRunnerFunc):
     ]
     with closing(run(add_arguments)) as p:
         p.expect(EOF)
-        assert 'Update succeeded.' in p.before.decode(), 'Keypair resource policy update not successful'
+        response = json.loads(p.before.decode())
+        assert response.get('ok') is True, 'Keypair resource policy update not successful'
 
     # Check if keypair resource policy is updated
     with closing(run(['--output=json', 'admin', 'keypair-resource-policy', 'list'])) as p:
@@ -93,10 +96,12 @@ def test_delete_keypair_resource_policy(run: ClientRunnerFunc):
     print("[ Delete keypair resource policy ]")
 
     # Delete keypair resource policy
-    with closing(run(['admin', 'keypair-resource-policy', 'delete', 'test_krp'])) as p:
+    with closing(run(['--output=json', 'admin', 'keypair-resource-policy', 'delete', 'test_krp'])) as p:
         p.sendline('y')
         p.expect(EOF)
-        assert 'Resource policy test_krp is deleted.' in p.before.decode(), 'Keypair resource policy deletion failed'
+        before = p.before.decode()
+        response = json.loads(before[before.index('{'):])
+        assert response.get('ok') is True, 'Keypair resource policy deletion failed'
 
 
 def test_list_keypair_resource_policy(run: ClientRunnerFunc):

--- a/src/ai/backend/test/cli_integration/admin/test_user.py
+++ b/src/ai/backend/test/cli_integration/admin/test_user.py
@@ -33,7 +33,8 @@ def test_add_user(run: ClientRunnerFunc):
         ]
         with closing(run(add_arguments)) as p:
             p.expect(EOF)
-            assert 'User testaccount1@lablup.com is created' in p.before.decode(), 'Account add error'
+            response = json.loads(p.before.decode())
+            assert response.get('ok') is True, 'Account creation failed: Account#1'
 
     if not bool(test_user2):
         # Add user
@@ -49,7 +50,8 @@ def test_add_user(run: ClientRunnerFunc):
         ]
         with closing(run(add_arguments)) as p:
             p.expect(EOF)
-            assert 'User testaccount2@lablup.com is created' in p.before.decode(), 'Account add error'
+            response = json.loads(p.before.decode())
+            assert response.get('ok') is True, 'Account creation failed: Account#2'
 
     if not bool(test_user3):
         # Add user
@@ -65,7 +67,8 @@ def test_add_user(run: ClientRunnerFunc):
         ]
         with closing(run(add_arguments)) as p:
             p.expect(EOF)
-            assert 'User testaccount3@lablup.com is created' in p.before.decode(), 'Account add error'
+            response = json.loads(p.before.decode())
+            assert response.get('ok') is True, 'Account creation failed: Account#3'
 
     # Check if user is added
     with closing(run(['--output=json', 'admin', 'user', 'list'])) as p:
@@ -171,20 +174,27 @@ def test_delete_user(run: ClientRunnerFunc):
     Testcase for user deletion.
     """
     print("[ Delete user ]")
-    with closing(run(['admin', 'user', 'purge', 'testaccount1@lablup.com'])) as p:
-        p.sendline('y')
-        p.expect(EOF)
-        assert 'User is deleted:' in p.before.decode(), 'Account deletion failed: Account#1'
 
-    with closing(run(['admin', 'user', 'purge', 'testaccount2@lablup.com'])) as p:
+    with closing(run(['--output=json', 'admin', 'user', 'purge', 'testaccount1@lablup.com'])) as p:
         p.sendline('y')
         p.expect(EOF)
-        assert 'User is deleted:' in p.before.decode(), 'Account deletion failed: Account#2'
+        before = p.before.decode()
+        response = json.loads(before[before.index('{'):])
+        assert response.get('ok') is True, 'Account deletion failed: Account#1'
 
-    with closing(run(['admin', 'user', 'purge', 'testaccount3@lablup.com'])) as p:
+    with closing(run(['--output=json', 'admin', 'user', 'purge', 'testaccount2@lablup.com'])) as p:
         p.sendline('y')
         p.expect(EOF)
-        assert 'User is deleted:' in p.before.decode(), 'Account deletion failed: Account#3'
+        before = p.before.decode()
+        response = json.loads(before[before.index('{'):])
+        assert response.get('ok') is True, 'Account deletion failed: Account#2'
+
+    with closing(run(['--output=json', 'admin', 'user', 'purge', 'testaccount3@lablup.com'])) as p:
+        p.sendline('y')
+        p.expect(EOF)
+        before = p.before.decode()
+        response = json.loads(before[before.index('{'):])
+        assert response.get('ok') is True, 'Account deletion failed: Account#3'
 
 
 def test_list_user(run: ClientRunnerFunc):

--- a/src/ai/backend/test/cli_integration/admin/test_user.py
+++ b/src/ai/backend/test/cli_integration/admin/test_user.py
@@ -1,74 +1,34 @@
 import json
 from contextlib import closing
+from typing import Callable, Tuple
 
 from ...utils.cli import EOF, ClientRunnerFunc
 
 
-def test_add_user(run: ClientRunnerFunc):
+def test_add_user(run: ClientRunnerFunc, users: Tuple[str]):
     """
     Testcase for user addition.
     """
     print("[ Add user ]")
 
-    # Check if test account exists
-    with closing(run(['--output=json', 'admin', 'user', 'list'])) as p:
-        p.expect(EOF)
-        decoded = p.before.decode()
-        loaded = json.loads(decoded)
-        user_list = loaded.get('items')
-
-    test_user1 = get_user_from_list(user_list, 'testaccount1')
-    test_user2 = get_user_from_list(user_list, 'testaccount2')
-    test_user3 = get_user_from_list(user_list, 'testaccount3')
-
-    if not bool(test_user1):
-        # Add user
+    # Add users
+    for i, user in enumerate(users):
         add_arguments = [
             '--output=json', 'admin', 'user', 'add',
-            '-u', 'testaccount1',
-            '-n', 'John Doe',
-            '--need-password-change', 'default',
-            'testaccount1@lablup.com',
-            '1q2w3e4r',
-        ]
-        with closing(run(add_arguments)) as p:
-            p.expect(EOF)
-            response = json.loads(p.before.decode())
-            assert response.get('ok') is True, 'Account creation failed: Account#1'
-
-    if not bool(test_user2):
-        # Add user
-        add_arguments = [
-            '--output=json', 'admin', 'user', 'add',
-            '-u', 'testaccount2',
-            '-n', 'John Roe',
-            '-r', 'admin',
-            '-s', 'inactive',
+            '-u', user['username'],
+            '-n', user['full_name'],
+            '-r', user['role'],
+            '-s', user['status'],
             'default',
-            'testaccount2@lablup.com',
-            '1q2w3e4r',
+            user['email'],
+            user['password'],
         ]
+        if user['need_password_change']:
+            add_arguments.append('--need-password-change')
         with closing(run(add_arguments)) as p:
             p.expect(EOF)
             response = json.loads(p.before.decode())
-            assert response.get('ok') is True, 'Account creation failed: Account#2'
-
-    if not bool(test_user3):
-        # Add user
-        add_arguments = [
-            '--output=json', 'admin', 'user', 'add',
-            '-u', 'testaccount3',
-            '-n', 'Richard Roe',
-            '-r', 'monitor',
-            '-s', 'before-verification',
-            '--need-password-change', 'default',
-            'testaccount3@lablup.com',
-            '1q2w3e4r',
-        ]
-        with closing(run(add_arguments)) as p:
-            p.expect(EOF)
-            response = json.loads(p.before.decode())
-            assert response.get('ok') is True, 'Account creation failed: Account#3'
+            assert response.get('ok') is True, f'Account creation failed: Account#{i}'
 
     # Check if user is added
     with closing(run(['--output=json', 'admin', 'user', 'list'])) as p:
@@ -78,63 +38,55 @@ def test_add_user(run: ClientRunnerFunc):
         user_list = loaded.get('items')
 
     assert isinstance(user_list, list), 'Expected user list'
-    added_user1 = get_user_from_list(user_list, 'testaccount1')
-    added_user2 = get_user_from_list(user_list, 'testaccount2')
-    added_user3 = get_user_from_list(user_list, 'testaccount3')
+    added_users = tuple(get_user_from_list(user_list, user['username'])
+                        for user in users)
 
-    assert bool(added_user1), 'Added account doesn\'t exist: Account#1'
-    assert added_user1.get('email') == 'testaccount1@lablup.com', 'E-mail mismatch: Account#1'
-    assert added_user1.get('full_name') == 'John Doe', 'Full name mismatch: Account#1'
-    assert added_user1.get('status') == 'active', 'User status mismatch: Account#1'
-    assert added_user1.get('role') == 'user', 'Role mismatch: Account#1'
-    assert added_user1.get('need_password_change') is True, 'Password change status mismatch: Account#1'
-
-    assert bool(added_user2), 'Added account doesn\'t exist: Account#2'
-    assert added_user2.get('email') == 'testaccount2@lablup.com', 'E-mail mismatch: Account#2'
-    assert added_user2.get('full_name') == 'John Roe', 'Full name mismatch: Account#2'
-    assert added_user2.get('status') == 'inactive', 'User status mismatch: Account#2'
-    assert added_user2.get('role') == 'admin', 'Role mismatch: Account#2'
-    assert added_user2.get('need_password_change') is False, 'Password change status mismatch: Account#2'
-
-    assert bool(added_user3), 'Added account doesn\'t exist: Account#3'
-    assert added_user3.get('email') == 'testaccount3@lablup.com', 'E-mail mismatch: Account#3'
-    assert added_user3.get('full_name') == 'Richard Roe', 'Full name mismatch: Account#3'
-    assert added_user3.get('status') == 'before-verification', 'User status mismatch: Account#3'
-    assert added_user3.get('role') == 'monitor', 'Role mismatch: Account#3'
-    assert added_user3.get('need_password_change') is True, 'Password change status mismatch: Account#3'
+    for i, (added_user, user) in enumerate(zip(added_users, users)):
+        assert bool(added_user), f'Added account doesn\'t exist: Account#{i+1}'
+        assert added_user.get('email') == user['email'], f'E-mail mismatch: Account#{i+1}'
+        assert added_user.get('full_name') == user['full_name'], f'Full name mismatch: Account#{i+1}'
+        assert added_user.get('status') == user['status'], f'User status mismatch: Account#{i+1}'
+        assert added_user.get('role') == user['role'], f'Role mismatch: Account#{i+1}'
+        assert added_user.get('need_password_change') is user['need_password_change'], f'E-mail mismatch: Account#{i+1}'
 
 
-def test_update_user(run: ClientRunnerFunc):
+def test_update_user(
+    run: ClientRunnerFunc,
+    users: Tuple[str],
+    gen_username: Callable[None, str],
+    gen_fullname: Callable[None, str]
+):
     """
-    Run this testcase after test_update_user.
+    Run this testcase after test_add_user.
     Testcase for user update.
     TODO: User update with roles is not fully covered yet.
     """
     print("[ Update user ]")
 
-    # Check if user exists
-    with closing(run(['--output=json', 'admin', 'user', 'list'])) as p:
-        p.expect(EOF)
-        decoded = p.before.decode()
-        loaded = json.loads(decoded)
-        user_list = loaded.get('items')
-        assert isinstance(user_list, list), 'Expected user list'
+    updated_users = [user.copy() for user in users]
+    for i, updated_user in enumerate(updated_users):
+        updated_user['username'] = gen_username()
+        updated_user['full_name'] = gen_fullname()
+        updated_user['status'] = ['inactive', 'active', 'active'][i]
+        updated_user['role'] = ['user', 'admin', 'monitor'][i]
+        updated_user['domain_name'] = ['default', 'default', 'default'][i]
+        updated_user['need_password_change'] = [False, True, False][i]
 
     # Update user
-    update_arguments = ['--output=json', 'admin', 'user', 'update', '-u', 'testaccount123', '-n', 'Foo Bar', '-s',
-                        'inactive', '-d', 'default', 'testaccount1@lablup.com']
-    with closing(run(update_arguments)) as p:
-        p.expect(EOF)
-
-    update_arguments = ['--output=json', 'admin', 'user', 'update', '-u', 'testaccount231', '-n', 'Baz Quz', '-s',
-                        'active', '-r', 'admin', '--need-password-change', 'testaccount2@lablup.com']
-    with closing(run(update_arguments)) as p:
-        p.expect(EOF)
-
-    update_arguments = ['--output=json', 'admin', 'user', 'update', '-u', 'testaccount312', '-n', 'Alice B.', '-s',
-                        'active', '-r', 'monitor', 'testaccount3@lablup.com']
-    with closing(run(update_arguments)) as p:
-        p.expect(EOF)
+    for updated_user, user in zip(updated_users, users):
+        update_arguments = [
+            '--output=json', 'admin', 'user', 'update',
+            '-u', updated_user['username'],
+            '-n', updated_user['full_name'],
+            '-s', updated_user['status'],
+            '-r', updated_user['role'],
+            '-d', updated_user['domain_name'],
+            user['email'],
+        ]
+        if updated_user['need_password_change']:
+            update_arguments.append('--need-password-change')
+        with closing(run(update_arguments)) as p:
+            p.expect(EOF)
 
     # Check if user is updated correctly
     with closing(run(['--output=json', 'admin', 'user', 'list'])) as p:
@@ -144,57 +96,31 @@ def test_update_user(run: ClientRunnerFunc):
         updated_user_list = after_update_loaded.get('items')
         assert isinstance(updated_user_list, list), 'Expected user list'
 
-    test_user1 = get_user_from_list(updated_user_list, 'testaccount123')
-    test_user2 = get_user_from_list(updated_user_list, 'testaccount231')
-    test_user3 = get_user_from_list(updated_user_list, 'testaccount312')
-
-    assert bool(test_user1), 'Account not found - Account#1'
-    assert test_user1.get('full_name') == 'Foo Bar', 'Full name mismatch: Account#1'
-    assert test_user1.get('status') == 'inactive', 'User status mismatch: Account#1'
-    assert test_user1.get('role') == 'user', 'Role mismatch: Account#1'
-    assert test_user1.get('need_password_change') is False, 'Password change status mismatch: Account#1'
-    assert test_user1.get('domain_name') == 'default', 'Domain mismatch: Account#1'
-
-    assert bool(test_user2), 'Account not found - Account#2'
-    assert test_user2.get('full_name') == 'Baz Quz', 'Full name mismatch: Account#2'
-    assert test_user2.get('status') == 'active', 'User status mismatch: Account#2'
-    assert test_user2.get('role') == 'admin', 'Role mismatch: Account#2'
-    assert test_user2.get('need_password_change') is True, 'Password change status mismatch: Account#2'
-
-    assert bool(test_user3), 'Account not found - Account#3'
-    assert test_user3.get('full_name') == 'Alice B.', 'Full name mismatch: Account#3'
-    assert test_user3.get('status') == 'active', 'User status mismatch: Account#3'
-    assert test_user3.get('role') == 'monitor', 'Role mismatch: Account#3'
-    assert test_user3.get('need_password_change') is False, 'Password change status mismatch: Account#3'
+    for i, updated_user in enumerate(updated_users):
+        user = get_user_from_list(updated_user_list, updated_user['username'])
+        assert bool(user), f'Account not found - Account#{i+1}'
+        assert user.get('full_name') == updated_user['full_name'], f'Full name mismatch: Account#{i+1}'
+        assert user.get('status') == updated_user['status'], f'User status mismatch: Account#{i+1}'
+        assert user.get('role') == updated_user['role'], f'Role mismatch: Account#{i+1}'
+        assert user.get('need_password_change') is updated_user['need_password_change'], \
+                                                        f'Password change status mismatch: Account#{i+1}'
+        assert user.get('domain_name') == updated_user['domain_name'], f'Domain mismatch: Account#{i+1}'
 
 
-def test_delete_user(run: ClientRunnerFunc):
+def test_delete_user(run: ClientRunnerFunc, users: Tuple[str]):
     """
     !!Run this testcase after running test_add_user
     Testcase for user deletion.
     """
     print("[ Delete user ]")
 
-    with closing(run(['--output=json', 'admin', 'user', 'purge', 'testaccount1@lablup.com'])) as p:
-        p.sendline('y')
-        p.expect(EOF)
-        before = p.before.decode()
-        response = json.loads(before[before.index('{'):])
-        assert response.get('ok') is True, 'Account deletion failed: Account#1'
-
-    with closing(run(['--output=json', 'admin', 'user', 'purge', 'testaccount2@lablup.com'])) as p:
-        p.sendline('y')
-        p.expect(EOF)
-        before = p.before.decode()
-        response = json.loads(before[before.index('{'):])
-        assert response.get('ok') is True, 'Account deletion failed: Account#2'
-
-    with closing(run(['--output=json', 'admin', 'user', 'purge', 'testaccount3@lablup.com'])) as p:
-        p.sendline('y')
-        p.expect(EOF)
-        before = p.before.decode()
-        response = json.loads(before[before.index('{'):])
-        assert response.get('ok') is True, 'Account deletion failed: Account#3'
+    for i, fake_user in enumerate(users):
+        with closing(run(['--output=json', 'admin', 'user', 'purge', fake_user['email']])) as p:
+            p.sendline('y')
+            p.expect(EOF)
+            before = p.before.decode()
+            response = json.loads(before[before.index('{'):])
+            assert response.get('ok') is True, f'Account deletion failed: Account#{i+1}'
 
 
 def test_list_user(run: ClientRunnerFunc):

--- a/src/ai/backend/test/cli_integration/admin/test_user.py
+++ b/src/ai/backend/test/cli_integration/admin/test_user.py
@@ -5,7 +5,7 @@ from typing import Callable, Tuple
 from ...utils.cli import EOF, ClientRunnerFunc
 
 
-def test_add_user(run: ClientRunnerFunc, users: Tuple[str]):
+def test_add_user(run: ClientRunnerFunc, users: Tuple[dict]):
     """
     Testcase for user addition.
     """
@@ -52,7 +52,7 @@ def test_add_user(run: ClientRunnerFunc, users: Tuple[str]):
 
 def test_update_user(
     run: ClientRunnerFunc,
-    users: Tuple[str],
+    users: Tuple[dict],
     gen_username: Callable[None, str],
     gen_fullname: Callable[None, str]
 ):
@@ -107,7 +107,7 @@ def test_update_user(
         assert user.get('domain_name') == updated_user['domain_name'], f'Domain mismatch: Account#{i+1}'
 
 
-def test_delete_user(run: ClientRunnerFunc, users: Tuple[str]):
+def test_delete_user(run: ClientRunnerFunc, users: Tuple[dict]):
     """
     !!Run this testcase after running test_add_user
     Testcase for user deletion.

--- a/src/ai/backend/test/cli_integration/conftest.py
+++ b/src/ai/backend/test/cli_integration/conftest.py
@@ -5,10 +5,11 @@ import os
 from pathlib import Path
 import re
 import secrets
-from typing import Iterator, Sequence
+from typing import Callable, Iterator, Sequence, Tuple
 
 import pexpect
 import pytest
+from faker import Faker
 
 from ai.backend.test.utils.cli import ClientRunnerFunc, EOF, run as _run
 
@@ -70,3 +71,30 @@ def temp_domain(domain_name: str, run: ClientRunnerFunc) -> Iterator[str]:
             p.expect_exact("Are you sure?")
             p.sendline("Y")
             p.expect(EOF)
+
+
+@pytest.fixture(scope="session")
+def users(n: int = 3) -> Tuple[str]:
+    fake = Faker()
+    return tuple(
+        {
+            'username': fake.user_name(),
+            'full_name': fake.name(),
+            'email': fake.email(),
+            'password': fake.password(8),
+            'role': ['user', 'admin', 'monitor'][i],
+            'status': ['active', 'inactive', 'before-verification', 'deleted'][i],
+            'need_password_change': [True, False, True][i],
+        }
+        for i in range(n)
+    )
+
+
+@pytest.fixture
+def gen_username() -> Callable[None, str]:
+    return lambda: Faker().user_name()
+
+
+@pytest.fixture
+def gen_fullname() -> Callable[None, str]:
+    return lambda: Faker().name()

--- a/src/ai/backend/test/cli_integration/conftest.py
+++ b/src/ai/backend/test/cli_integration/conftest.py
@@ -74,7 +74,7 @@ def temp_domain(domain_name: str, run: ClientRunnerFunc) -> Iterator[str]:
 
 
 @pytest.fixture(scope="session")
-def users(n: int = 3) -> Tuple[str]:
+def users(n: int = 3) -> Tuple[dict]:
     fake = Faker()
     return tuple(
         {

--- a/src/ai/backend/test/cli_integration/conftest.py
+++ b/src/ai/backend/test/cli_integration/conftest.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import re
 import secrets
-from collections import namedtuple
 from contextlib import closing
 from pathlib import Path
 from typing import Callable, Iterator, Sequence, Tuple
@@ -89,28 +88,6 @@ def users(n: int = 3) -> Tuple[dict]:
         }
         for i in range(n)
     )
-
-
-KeypairOption = namedtuple('KeypairOption',
-                           ('is_active', 'is_admin', 'rate_limit', 'resource_policy'))
-
-
-@pytest.fixture(scope="module")
-def keypair_options() -> Tuple[KeypairOption]:
-    return tuple([
-        KeypairOption(is_active=False, is_admin=True, rate_limit=25000, resource_policy='default'),
-        KeypairOption(is_active=True, is_admin=False, rate_limit=None, resource_policy='default'),
-        KeypairOption(is_active=True, is_admin=True, rate_limit=30000, resource_policy='default'),
-    ])
-
-
-@pytest.fixture(scope="module")
-def new_keypair_options() -> Tuple[KeypairOption]:
-    return tuple([
-        KeypairOption(is_active=True, is_admin=False, rate_limit=15000, resource_policy='default'),
-        KeypairOption(is_active=False, is_admin=True, rate_limit=15000, resource_policy='default'),
-        KeypairOption(is_active=False, is_admin=False, rate_limit=10000, resource_policy='default'),
-    ])
 
 
 @pytest.fixture


### PR DESCRIPTION
WARNING: This PR should be merged (if confirmed) after #6 .

In this PR, I replaced hard-coded user data to `pytest.fixture` since the same data is used in multiple tests. Also, I randomized the data using `faker` to avoid errors caused by database integrity constraint.

Refs:
- lablup/backend.ai#352